### PR TITLE
Added create, next, entry commands.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,10 @@ chag workflow is:
 
 1. As you develop changes, add to your changelog file under a changelog
    section titled ``Unreleased``.
+    * You can run ``chag create`` to create a ``CHANGELOG.md`` file if one does not exist.
+    * Next, to create a new "Unreleased" entry, run ``chag next``.
 2. As you develop features, append items to your changelog.
+    * You can do this by running ``chag entry --contents <your entry>``
 3. When your work is ready to be released, execute ``chag update X.Y.Z``
    to update the WIP changelog entry to an actual version number. Substitute
    ``X.Y.Z`` with the version of the next tagged release.
@@ -116,6 +119,52 @@ Usage
       latest     Get the latest tag in a changelog.
       tag        Create an annotated git tag based on a changelog entry.
       update     Updates the version and date of the most recent changelog entry.
+      create     Creates a new CHANGELOG.md file with a standard header.
+      entry      Add a quick entry to the current version.
+      next       Create a new unreleased version in changelog file.
+
+next
+----
+
+Create a new unreleased version in changelog file.
+
+::
+
+   Usage: chag next
+
+   Creates a new unreleased version inside of the changelog file.
+
+   Options:
+     --help     Displays this message.
+
+entry
+-----
+
+Add a quick entry to the current version.
+
+::
+
+   Usage: chag entry --contents <contents>
+
+   Creates a new entry inside of the changelog's latest version with --contents as it's body.
+
+   Options:
+     --contents The body of the entry.
+     --help     Displays this message.
+
+create
+------
+
+Creates a new CHANGELOG.md with a standard header (if one does not exist).
+
+::
+
+   Usage: chag create [--help]
+
+   Creates a new CHANGELOG.md file with a changelog header if one does not exist.
+
+   Options:
+     --help     Displays this message.
 
 contents
 ~~~~~~~~

--- a/chag
+++ b/chag
@@ -24,11 +24,51 @@ Options:
   --version  Displays the version number.
 
 Commands:
-  contents   Get the contents of a changelog entry.
-  entries    List all versions in a changelog file.
-  latest     Get the latest tag in a changelog.
-  tag        Create an annotated git tag based on a changelog entry.
-  update     Updates the version and date of the most recent changelog entry.
+  contents Get the contents of a changelog entry.
+  entries  List all versions in a changelog file.
+  latest   Get the latest tag in a changelog.
+  tag      Create an annotated git tag based on a changelog entry.
+  update   Updates the version and date of the most recent changelog entry.
+  create   Creates a new CHANGELOG.md file with a standard header.
+  entry    Add a quick entry to the current version.
+  next     Create a new unreleased version in changelog file.
+EOT
+  exit 0
+}
+
+create_usage() {
+  cat <<EOT
+Usage: chag create [--help]
+
+Creates a new CHANGELOG.md file with a changelog header if one does not exist.
+
+Options:
+  --help     Displays this message.
+EOT
+  exit 0
+}
+
+entry_usage() {
+  cat <<EOT
+Usage: chag entry --contents <contents>
+
+Creates a new entry inside of the changelog's latest version with --contents as it's body.
+
+Options:
+  --contents The body of the entry.
+  --help     Displays this message.
+EOT
+  exit 0
+}
+
+next_usage() {
+  cat <<EOT
+Usage: chag next
+
+Creates a new unreleased version inside of the changelog file.
+
+Options:
+  --help     Displays this message.
 EOT
   exit 0
 }
@@ -194,6 +234,44 @@ get_entry() {
   trim "$(sed -n "$((found_line + 1))","$end_line"p < $FILENAME)"
 }
 
+create() {
+  FILENAME="CHANGELOG.md"
+  HEADER="# CHANGELOG \n"
+  [ -f "$FILENAME" ] || printf "${HEADER}" >> $FILENAME
+
+  exit 0
+}
+
+entry() {
+  OPOS=$(grep -n -m 1 "##" $FILENAME | cut -f1 -d:)
+  if [ ! -z $OPOS ]; then
+    WLTOTAL=$(cat $FILENAME | wc -l)
+    INSERT_AT=$(($OPOS + 2))
+
+    if [ $INSERT_AT -gt $WLTOTAL ]; then
+      echo "" >> $FILENAME
+    fi
+
+    sed -i "${INSERT_AT}i \* ${CONTENTS}" $FILENAME
+  else
+    die "No releases found. Please create a release first (e.g. 'chag next')"
+  fi
+
+  exit 0
+}
+
+next() {
+  # Contains a version already
+  if grep -q "##" $FILENAME; then
+    sed -i "0,/##/s//## Unreleased\n\n\n##/" $FILENAME
+  # No previous versions
+  else
+    printf "\n## Unreleased\n\n" >> $FILENAME
+  fi
+
+  exit 0
+}
+
 # Removes leading and trailing whitespace from the provided input.
 trim() {
   local var=$@
@@ -202,12 +280,13 @@ trim() {
   echo "$var"
 }
 
+
 # Show help if no options are provided or if "--help" is passed.
 [ $# -eq 0 ] || [ "$1" == "--help" ] && usage
 # Show the version if just --version is provided.
 [ "$1" == '--version' ] && version && exit 0
 # Ensure a valid command was passed.
-VALID="contents|tag|latest|entries|update"
+VALID="contents|tag|latest|entries|update|entry|next|create"
 [[ $VALID == *$1* ]] || die "Available commands: ${VALID}"
 
 COMMAND="$1"; shift
@@ -218,6 +297,7 @@ while [ $# -gt 0 ]; do
     --help) "${COMMAND}_usage";;
     --file) FILENAME=${1:?"--file cannot be empty"}; shift;;
     --tag) TAG=${1:?"--tag cannot be empty"}; shift;;
+    --contents) CONTENTS=${1:?"--contents cannot be empty"}; shift;;
     --addv) ADDV=1 ;;
     --sign|-s) SIGN="--sign" ;;
     --force|-f) FORCE="--force" ;;
@@ -226,11 +306,10 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# Find the default changelog if needed.
 if [ -z "$FILENAME" ]; then
   FILENAME=`pwd`"/CHANGELOG.md"
-  [ -f "$FILENAME" ] || FILENAME=`pwd`"/CHANGELOG"
+  ([ -f "$FILENAME" ] || [ $COMMAND == "create" ]) || FILENAME=`pwd`"/CHANGELOG"
 fi
-[ -f "$FILENAME" ] || die "File not found: $FILENAME"
+([ -f "$FILENAME" ] || [ $COMMAND == "create" ]) || die "File not found: $FILENAME"
 
 $COMMAND $opt $@

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,9 @@ set -e
 
 [ -z "$CHAG_DIR" ] && CHAG_DIR="/usr/local/bin"
 [ -z "$CHAG_VERSION" ] && CHAG_VERSION="master"
+[ -z "$CHAG_VENDOR" ] && CHAG_VENDOR="mtdowling"
 
-CHAG_SOURCE="https://raw.githubusercontent.com/mtdowling/chag/$CHAG_VERSION/chag"
+CHAG_SOURCE="https://raw.githubusercontent.com/$CHAG_VENDOR/chag/$CHAG_VERSION/chag"
 
 echo "=> Downloading chag to '$CHAG_DIR'"
 curl -sS "$CHAG_SOURCE" -o "$CHAG_DIR/chag" || {

--- a/test/chag.bats
+++ b/test/chag.bats
@@ -27,5 +27,5 @@
 @test "Invalid commands fail" {
   run ./chag foo
   [ $status -eq 1 ]
-  [ "${lines[0]}" == "[FAILURE] Available commands: contents|tag|latest|entries|update" ]
+  [ "${lines[0]}" == "[FAILURE] Available commands: contents|tag|latest|entries|update|entry|next|create" ]
 }

--- a/test/create.bats
+++ b/test/create.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "--help prints help" {
+  run ./chag create --help
+  [ $status -eq 0 ]
+  [ $(expr "${lines[0]}" : "Usage: chag create") -ne 0 ]
+}
+
+@test "Invalid options fail" {
+  run ./chag create --foo
+  [ $status -eq 1 ]
+  [ "${lines[0]}" == "[FAILURE] Unknown option '--foo'" ]
+}

--- a/test/entry.bats
+++ b/test/entry.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "--help prints help" {
+  run ./chag entry --help
+  [ $status -eq 0 ]
+  [ $(expr "${lines[0]}" : "Usage: chag entry --contents") -ne 0 ]
+}
+
+@test "Invalid options fail" {
+  run ./chag entry --foo
+  [ $status -eq 1 ]
+  [ "${lines[0]}" == "[FAILURE] Unknown option '--foo'" ]
+}

--- a/test/next.bats
+++ b/test/next.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "--help prints help" {
+  run ./chag next --help
+  [ $status -eq 0 ]
+  [ $(expr "${lines[0]}" : "Usage: chag next") -ne 0 ]
+}
+
+@test "Invalid options fail" {
+  run ./chag next --foo
+  [ $status -eq 1 ]
+  [ "${lines[0]}" == "[FAILURE] Unknown option '--foo'" ]
+}


### PR DESCRIPTION
Added a few commands to make it easier to add and manipulate the changelog (without the need to use an editor).

Adds the following:

       create     Creates a new CHANGELOG.md file with a standard header.
        entry      Add a quick entry to the current version.
        next       Create a new unreleased version in changelog file.

Allows to change vendor on install script to be friendlier to downstream
repos and automation.