### PR TITLE
chag tag: added --cleanup=whitespace (fixes #7)

### DIFF
--- a/chag
+++ b/chag
@@ -132,7 +132,7 @@ tag() {
   fi
 
   # Run the command and get the exit code
-  local cmd="git tag $SIGN $FORCE -a -F - $real_tag"
+  local cmd="git tag $SIGN $FORCE -a --cleanup=whitespace -F - $real_tag"
   # Strip extra spaces from the command
   cmd=$(echo $cmd | sed 's/\s+/\s/')
   echo "Tagging $real_tag with the following annotation:"

--- a/test/tag.bats
+++ b/test/tag.bats
@@ -24,7 +24,7 @@ chagcmd="$BATS_TEST_DIRNAME/../chag"
   [ "${lines[1]}" == '===[ BEGIN ]===' ]
   [ "${lines[2]}" == '* Correcting ``--debug`` description.' ]
   [ "${lines[3]}" == '===[  END  ]===' ]
-  [ "${lines[4]}" == 'Running git command: git tag -a -F - 0.0.2' ]
+  [ "${lines[4]}" == 'Running git command: git tag -a --cleanup=whitespace -F - 0.0.2' ]
   [ "${lines[5]}" == '[SUCCESS] Tagged 0.0.2' ]
   run git tag -l -n1 0.0.2
   cd -


### PR DESCRIPTION
chag tag caused headings that are part of a changelog entry content
to be ignored because git interpreted them as comments.

This fix preserves lines prefixed with a # when creating the annotated tag and
therefore all lines that are markdown headers are preserved in the annotation
message.

This patch also fixes the tests according to the new behavior.